### PR TITLE
Build gaal launch homepage and deploy to GitHub Pages

### DIFF
--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -61,7 +61,7 @@ export default function Header() {
             </svg>
             Star on GitHub
           </span>
-          <span className="btn-chevron primary">
+          <span className="btn-chevron primary max-sm:!hidden">
             <svg
               width="14"
               height="14"

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -394,10 +394,10 @@ function YamlBlock() {
           <span className="yml-key">schema</span>
           <span className="yml-punct">:</span> <span className="yml-num">1</span>
           {'\n\n'}
+          <span className="yml-comment"># 1. code repos to keep cloned</span>
+          {'\n'}
           <span className="yml-key">repositories</span>
           <span className="yml-punct">:</span>
-          {'                              '}
-          <span className="yml-comment"># 1. code repos to keep cloned</span>
           {'\n  - '}
           <span className="yml-key">source</span>
           <span className="yml-punct">:</span>{' '}
@@ -407,35 +407,35 @@ function YamlBlock() {
           <span className="yml-punct">:</span>{' '}
           <span className="yml-str">~/code/gaal</span>
           {'\n\n'}
+          <span className="yml-comment"># 2. AI agent skills</span>
+          {'\n'}
           <span className="yml-key">skills</span>
           <span className="yml-punct">:</span>
-          {'                                    '}
-          <span className="yml-comment"># 2. AI agent skills</span>
           {'\n  - '}
           <span className="yml-key">source</span>
           <span className="yml-punct">:</span>{' '}
           <span className="yml-str">github.com/obra/superpowers</span>
+          {'\n    '}
+          <span className="yml-comment">
+            # auto-detect every installed agent
+          </span>
           {'\n    '}
           <span className="yml-key">agents</span>
           <span className="yml-punct">:</span>{' '}
           <span className="yml-punct">[</span>
           <span className="yml-str">"*"</span>
           <span className="yml-punct">]</span>
-          {'                          '}
-          <span className="yml-comment">
-            # auto-detect every installed agent
-          </span>
+          {'\n    '}
+          <span className="yml-comment"># shared across projects</span>
           {'\n    '}
           <span className="yml-key">global</span>
           <span className="yml-punct">:</span>{' '}
           <span className="yml-bool">true</span>
-          {'                           '}
-          <span className="yml-comment"># shared across projects</span>
           {'\n\n'}
+          <span className="yml-comment"># 3. MCP servers</span>
+          {'\n'}
           <span className="yml-key">mcps</span>
           <span className="yml-punct">:</span>
-          {'                                      '}
-          <span className="yml-comment"># 3. MCP servers</span>
           {'\n  - '}
           <span className="yml-key">inline</span>
           <span className="yml-punct">:</span>


### PR DESCRIPTION
## Summary

Replaces the TanStack starter with the full gaal launch homepage targeting solo developers, plus a GitHub Pages deploy pipeline.

- **Dark Particles design system** (Urbanist via Google Fonts, lime \`#DEFF9A\` accent, pure black canvas, shadow-free depth via value contrast)
- **Seven sections** per copy spec: hero, problem, animated terminal demo, how it works, 17-agent coverage grid, trust row, Community Edition newsletter capture
- **Animated two-panel terminal demo** (import-then-sync flow, IntersectionObserver triggered, auto-loops)
- **Annotated YAML example** with project/global scope callout
- **Loops.co newsletter form** stub (form ID still needs filling in before launch)
- **SVG favicon** matching the header logo, replaces the default \`.ico\`
- **Mobile audit** complete across 375 / 390 / 412 / 768 / 1440; YAML overflow and nav chevron pinch fixed
- **GitHub Pages workflow** with TanStack Start prerender + SPA fallback (\`actions/configure-pages\` auto-detects the project base path)
- Strategy and brief docs included under \`docs/\`; copy spec at \`docs/superpowers/specs/2026-04-17-gaal-homepage-copy-design.md\`

## Test plan

- [x] Build succeeds locally with \`BASE_PATH=/gaal-website/ npm run build\` (3 prerendered pages, correct asset prefixes)
- [x] All 7 sections render at 375 / 390 / 412 / 768 / 1440
- [x] Terminal demo animates and loops
- [x] Newsletter form stubbed (Loops.co form ID still TODO)
- [x] Favicon serves at the right path
- [ ] After merge: enable Pages → Source: GitHub Actions in repo settings, then confirm the workflow completes and the deployed page renders