### PR TITLE
Add documentation links to nav, footer, and hero CTA

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -40,6 +40,16 @@ export default function Footer() {
                 Supported agents
               </a>
             </li>
+            <li>
+              <a
+                href="https://docs.getgaal.com"
+                target="_blank"
+                rel="noreferrer"
+                className="text-[var(--fg-muted)] hover:text-[var(--accent)]"
+              >
+                Docs
+              </a>
+            </li>
           </ul>
         </div>
 

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -33,6 +33,14 @@ export default function Header() {
             Agents
           </a>
           <a
+            href="https://docs.getgaal.com"
+            target="_blank"
+            rel="noreferrer"
+            className="nav-link"
+          >
+            Docs
+          </a>
+          <a
             href={REPO}
             target="_blank"
             rel="noreferrer"

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -147,6 +147,34 @@ function Hero() {
             go install github.com/getgaal/gaal@latest
           </code>
         </p>
+
+        <div
+          className="mt-5 flex justify-center rise-in sm:justify-start"
+          style={{ animationDelay: '400ms' }}
+        >
+          <a
+            href="https://docs.getgaal.com"
+            target="_blank"
+            rel="noreferrer"
+            className="btn-pill dark"
+          >
+            View the documentation
+            <svg
+              width="14"
+              height="14"
+              viewBox="0 0 24 24"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth="2.4"
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              aria-hidden="true"
+              focusable="false"
+            >
+              <path d="M9 6l6 6-6 6" />
+            </svg>
+          </a>
+        </div>
       </div>
     </section>
   )

--- a/src/styles.css
+++ b/src/styles.css
@@ -277,6 +277,18 @@ a:focus-visible {
   color: var(--accent);
 }
 
+.btn-pill.dark {
+  background: #000;
+  color: var(--fg);
+  border: 1px solid rgba(255, 255, 255, 0.2);
+}
+
+.btn-pill.dark:hover {
+  border-color: var(--accent);
+  color: var(--accent);
+  transform: translateY(-1px);
+}
+
 /* Circle chevron companion - canonical CTA pairing */
 .btn-chevron {
   display: inline-flex;


### PR DESCRIPTION
## Summary
- Add "Docs" link (→ `https://docs.getgaal.com`) to the header nav and the footer Product column.
- Add a dark pill CTA ("View the documentation") directly below the hero's "macOS · Linux · Windows · or go install …" line.
- Introduce a `.btn-pill.dark` variant in `styles.css` for the new low-emphasis hero button.

Closes #6

## Test plan
- [x] Header shows Demo / How it works / Agents / **Docs** / GitHub — Docs opens in new tab
- [x] Footer Product column includes **Docs** alongside Demo / How it works / Supported agents
- [x] Hero renders the black pill under the system support line; `target="_blank"` and `href="https://docs.getgaal.com"` confirmed in the DOM
- [x] `.btn-pill.dark` computed styles: `bg rgb(0,0,0)`, white text, `rgba(255,255,255,0.2)` border
- [ ] Visual QA on mobile viewport

🤖 Generated with [Claude Code](https://claude.com/claude-code)