### PR TITLE
Add light theme and theme toggle

### DIFF
--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -9,9 +9,9 @@ export default function Footer() {
         <div className="sm:col-span-2">
           <div className="mb-3 flex items-center gap-2">
             <span className="inline-flex h-6 w-6 items-center justify-center rounded-full bg-[var(--accent)]">
-              <span className="h-1 w-1 rounded-full bg-black" />
+              <span className="h-1 w-1 rounded-full bg-[var(--on-accent)]" />
             </span>
-            <span className="text-base font-semibold text-white">gaal</span>
+            <span className="text-base font-semibold text-[var(--fg)]">gaal</span>
           </div>
           <p className="max-w-md text-sm text-[var(--fg-muted)]">
             One YAML. Every coding agent. Every machine. The Governed Agent
@@ -94,7 +94,7 @@ export default function Footer() {
         <span className="ticker-dot">getgaal</span>
         <a
           href="mailto:hello@getgaal.com"
-          className="center text-[#aaaaaa] hover:text-[var(--accent)]"
+          className="center text-[var(--fg-dim)] hover:text-[var(--accent)]"
         >
           hello@getgaal.com
         </a>

--- a/src/components/Header.tsx
+++ b/src/components/Header.tsx
@@ -1,10 +1,11 @@
 import { Link } from '@tanstack/react-router'
+import ThemeToggle from './ThemeToggle'
 
 const REPO = 'https://github.com/getgaal/gaal'
 
 export default function Header() {
   return (
-    <header className="sticky top-0 z-40 border-b border-[var(--line)] bg-black/80 backdrop-blur-lg">
+    <header className="sticky top-0 z-40 border-b border-[var(--line)] bg-[var(--bg-scrim)] backdrop-blur-lg">
       <nav className="page-wrap flex items-center gap-4 py-4">
         <Link to="/" className="flex items-center gap-2.5 no-underline">
           <span
@@ -12,9 +13,9 @@ export default function Header() {
             className="relative inline-flex h-7 w-7 items-center justify-center rounded-full bg-[var(--accent)]"
           >
             <span className="absolute inset-0 rounded-full bg-[var(--accent)] opacity-60 blur-[6px]" />
-            <span className="relative h-1.5 w-1.5 rounded-full bg-black" />
+            <span className="relative h-1.5 w-1.5 rounded-full bg-[var(--on-accent)]" />
           </span>
-          <span className="text-base font-semibold tracking-tight text-white">
+          <span className="text-base font-semibold tracking-tight text-[var(--fg)]">
             gaal
           </span>
           <span className="rounded-full border border-[var(--line)] bg-[var(--surface-2)] px-2 py-0.5 text-[0.65rem] font-medium tracking-wide text-[var(--fg-muted)]">
@@ -50,12 +51,14 @@ export default function Header() {
           </a>
         </div>
 
-        <a
-          href={REPO}
-          target="_blank"
-          rel="noreferrer"
-          className="cta-pair ml-auto sm:ml-0"
-        >
+        <div className="ml-auto flex items-center gap-3 sm:ml-0">
+          <ThemeToggle />
+          <a
+            href={REPO}
+            target="_blank"
+            rel="noreferrer"
+            className="cta-pair"
+          >
           <span className="btn-pill primary">
             <svg
               width="14"
@@ -69,23 +72,24 @@ export default function Header() {
             </svg>
             Star on GitHub
           </span>
-          <span className="btn-chevron primary max-sm:!hidden">
-            <svg
-              width="14"
-              height="14"
-              viewBox="0 0 24 24"
-              fill="none"
-              stroke="currentColor"
-              strokeWidth="2.4"
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              aria-hidden="true"
-              focusable="false"
-            >
-              <path d="M9 6l6 6-6 6" />
-            </svg>
-          </span>
-        </a>
+            <span className="btn-chevron primary max-sm:!hidden">
+              <svg
+                width="14"
+                height="14"
+                viewBox="0 0 24 24"
+                fill="none"
+                stroke="currentColor"
+                strokeWidth="2.4"
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                aria-hidden="true"
+                focusable="false"
+              >
+                <path d="M9 6l6 6-6 6" />
+              </svg>
+            </span>
+          </a>
+        </div>
       </nav>
     </header>
   )

--- a/src/components/InstallBlock.tsx
+++ b/src/components/InstallBlock.tsx
@@ -32,7 +32,7 @@ export default function InstallBlock({
         <span className="term-prompt select-none" aria-hidden="true">
           $
         </span>
-        <span className="term-cmd min-w-0 flex-1 truncate text-white">
+        <span className="term-cmd min-w-0 flex-1 truncate">
           {INSTALL_CMD}
         </span>
       </div>

--- a/src/components/NewsletterForm.tsx
+++ b/src/components/NewsletterForm.tsx
@@ -35,7 +35,7 @@ export default function NewsletterForm() {
   if (status === 'success') {
     return (
       <div className="flex items-center gap-3 rounded-xl border border-[var(--line)] bg-[var(--surface-2)] px-5 py-4 text-sm">
-        <span className="flex h-7 w-7 items-center justify-center rounded-full bg-[var(--accent)] text-black">
+        <span className="flex h-7 w-7 items-center justify-center rounded-full bg-[var(--accent)] text-[var(--on-accent)]">
           <svg
             width="14"
             height="14"
@@ -52,7 +52,7 @@ export default function NewsletterForm() {
           </svg>
         </span>
         <span>
-          <span className="font-semibold text-white">You're on the list.</span>{' '}
+          <span className="font-semibold text-[var(--fg)]">You're on the list.</span>{' '}
           <span className="text-[var(--fg-muted)]">
             We'll email you when Community Edition ships.
           </span>

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,0 +1,155 @@
+import { useEffect, useState } from 'react'
+
+type Theme = 'system' | 'light' | 'dark'
+type Resolved = 'light' | 'dark'
+
+const STORAGE_KEY = 'gaal-theme'
+
+function systemPrefers(): Resolved {
+  if (typeof window === 'undefined') return 'dark'
+  return window.matchMedia('(prefers-color-scheme: light)').matches
+    ? 'light'
+    : 'dark'
+}
+
+function readStored(): Theme {
+  if (typeof window === 'undefined') return 'system'
+  const raw = window.localStorage.getItem(STORAGE_KEY)
+  return raw === 'light' || raw === 'dark' || raw === 'system' ? raw : 'system'
+}
+
+function applyTheme(theme: Theme) {
+  if (typeof document === 'undefined') return
+  const resolved: Resolved = theme === 'system' ? systemPrefers() : theme
+  document.documentElement.setAttribute('data-theme', resolved)
+  document.documentElement.dataset.themePref = theme
+}
+
+export default function ThemeToggle({ className }: { className?: string }) {
+  const [theme, setTheme] = useState<Theme>('system')
+  const [mounted, setMounted] = useState(false)
+
+  useEffect(() => {
+    setTheme(readStored())
+    setMounted(true)
+  }, [])
+
+  useEffect(() => {
+    if (!mounted) return
+    applyTheme(theme)
+    window.localStorage.setItem(STORAGE_KEY, theme)
+  }, [theme, mounted])
+
+  useEffect(() => {
+    if (!mounted) return
+    const mql = window.matchMedia('(prefers-color-scheme: light)')
+    const onChange = () => {
+      if (readStored() === 'system') applyTheme('system')
+    }
+    mql.addEventListener('change', onChange)
+    return () => mql.removeEventListener('change', onChange)
+  }, [mounted])
+
+  const cycle = () => {
+    setTheme((t) => (t === 'system' ? 'light' : t === 'light' ? 'dark' : 'system'))
+  }
+
+  const label =
+    theme === 'system'
+      ? 'Theme: match system'
+      : theme === 'light'
+        ? 'Theme: light'
+        : 'Theme: dark'
+
+  return (
+    <button
+      type="button"
+      onClick={cycle}
+      aria-label={`${label}. Click to cycle themes.`}
+      title={label}
+      className={[
+        'inline-flex h-9 w-9 shrink-0 items-center justify-center rounded-full border border-[var(--outline)] text-[var(--fg-muted)] transition hover:border-[var(--accent)] hover:text-[var(--accent)]',
+        className ?? '',
+      ].join(' ')}
+    >
+      {/* Render only after mount so SSR markup matches any theme. */}
+      {!mounted ? (
+        <Placeholder />
+      ) : theme === 'system' ? (
+        <SystemIcon />
+      ) : theme === 'light' ? (
+        <SunIcon />
+      ) : (
+        <MoonIcon />
+      )}
+    </button>
+  )
+}
+
+function Placeholder() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      aria-hidden="true"
+    />
+  )
+}
+
+function SunIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <circle cx="12" cy="12" r="4" />
+      <path d="M12 2v2M12 20v2M4.93 4.93l1.41 1.41M17.66 17.66l1.41 1.41M2 12h2M20 12h2M4.93 19.07l1.41-1.41M17.66 6.34l1.41-1.41" />
+    </svg>
+  )
+}
+
+function MoonIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <path d="M21 12.8A9 9 0 1 1 11.2 3a7 7 0 0 0 9.8 9.8Z" />
+    </svg>
+  )
+}
+
+function SystemIcon() {
+  return (
+    <svg
+      width="16"
+      height="16"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      strokeWidth="2"
+      strokeLinecap="round"
+      strokeLinejoin="round"
+      aria-hidden="true"
+    >
+      <rect x="3" y="4" width="18" height="12" rx="2" />
+      <path d="M8 20h8M12 16v4" />
+    </svg>
+  )
+}

--- a/src/routes/__root.tsx
+++ b/src/routes/__root.tsx
@@ -10,6 +10,11 @@ import appCss from '../styles.css?url'
 const BASE = import.meta.env.BASE_URL ?? '/'
 const favicon = `${BASE}favicon.svg?v=2`
 
+// Inline script injected before hydration so the resolved theme is applied
+// before the first paint — avoids a flash of the wrong palette for users
+// whose stored preference (or OS preference) doesn't match the SSR default.
+const THEME_BOOT = `(()=>{try{var s=localStorage.getItem('gaal-theme');var p=s==='light'||s==='dark'||s==='system'?s:'system';var r=p==='system'?(matchMedia('(prefers-color-scheme: light)').matches?'light':'dark'):p;var h=document.documentElement;h.setAttribute('data-theme',r);h.dataset.themePref=p;}catch(e){}})();`
+
 export const Route = createRootRoute({
   head: () => ({
     meta: [
@@ -50,9 +55,12 @@ function RootDocument({ children }: { children: React.ReactNode }) {
   }, [])
 
   return (
-    <html lang="en" className="dark">
+    <html lang="en" data-theme="dark">
       <head>
         <HeadContent />
+        {/* Inline pre-hydration theme boot. eslint-disable-next-line react/no-danger */}
+        {/* eslint-disable-next-line react/no-danger */}
+        <script dangerouslySetInnerHTML={{ __html: THEME_BOOT }} />
       </head>
       <body className="font-sans antialiased">
         <div id="app">

--- a/src/routes/index.tsx
+++ b/src/routes/index.tsx
@@ -83,7 +83,7 @@ function Hero() {
           Stop copy-pasting <code>CLAUDE.md</code> into{' '}
            every project, re-registering MCP servers in every
           agent's JSON, and hoping your laptop and your desktop stay in sync.{' '}
-          <span className="text-white">gaal</span> keeps your skills, MCPs, and
+          <span className="text-[var(--fg)]">gaal</span> keeps your skills, MCPs, and
           repos in one file, then applies them to Claude Code, Cursor, Codex,
           and 14 other agents with one command.
         </p>
@@ -201,7 +201,7 @@ function HeroBackdrop() {
             cx={s.x}
             cy={s.y}
             r={s.r}
-            fill={s.accent ? 'url(#star-grad)' : '#ffffff'}
+            fill={s.accent ? 'url(#star-grad)' : 'var(--star)'}
             opacity={s.o}
           />
         ))}
@@ -213,7 +213,7 @@ function HeroBackdrop() {
             y1={l.y1}
             x2={l.x2}
             y2={l.y2}
-            stroke="#ffffff"
+            stroke="var(--star)"
             strokeWidth="0.5"
             opacity="0.06"
           />
@@ -282,7 +282,7 @@ function Problem() {
               server. Tweak a skill on your laptop and your desktop doesn't
               know.
             </p>
-            <p className="text-white">
+            <p className="text-[var(--fg)]">
               4 agents × 2 machines is{' '}
               <span className="accent-word">8 places</span> where one source of
               truth should live. No way to answer{' '}
@@ -303,7 +303,7 @@ function Problem() {
                     {row.files.map((f) => (
                       <code
                         key={f}
-                        className="!border-[var(--line)] !bg-black !text-[var(--fg-muted)]"
+                        className="!border-[var(--line)] !bg-[var(--bg)] !text-[var(--fg-muted)]"
                       >
                         {f}
                       </code>
@@ -402,7 +402,7 @@ function SequenceItem({
     <div className="flex gap-5">
       <span className="numeral leading-none shrink-0 w-12 text-right">{n}</span>
       <div>
-        <h3 className="mb-1.5 text-lg font-semibold text-white">{title}</h3>
+        <h3 className="mb-1.5 text-lg font-semibold text-[var(--fg)]">{title}</h3>
         <p className="text-sm text-[var(--fg-muted)] leading-relaxed">{body}</p>
       </div>
     </div>
@@ -670,7 +670,7 @@ function InstallCard({
       <p className="font-mono text-[0.68rem] uppercase tracking-widest text-[var(--accent)]">
         {label}
       </p>
-      <div className="rounded-xl border border-[var(--line)] bg-[var(--surface-0)] px-4 py-3 font-mono text-[0.82rem] text-white">
+      <div className="rounded-xl border border-[var(--line)] bg-[var(--surface-0)] px-4 py-3 font-mono text-[0.82rem] text-[var(--fg)]">
         <span className="term-prompt mr-2 select-none" aria-hidden="true">
           $
         </span>
@@ -772,7 +772,7 @@ function ResourceTile({
   return (
     <article className="card-xl">
       <span className="numeral mb-5 block">{n}</span>
-      <h3 className="mb-2 text-lg font-semibold text-white">{title}</h3>
+      <h3 className="mb-2 text-lg font-semibold text-[var(--fg)]">{title}</h3>
       <p className="text-sm text-[var(--fg-muted)] leading-relaxed">{body}</p>
     </article>
   )

--- a/src/styles.css
+++ b/src/styles.css
@@ -7,7 +7,8 @@
   --font-mono: "JetBrains Mono", ui-monospace, SFMono-Regular, Menlo, monospace;
 }
 
-:root {
+:root,
+:root[data-theme='dark'] {
   /* Dark Particles. Design tokens from DESIGN.md */
   --bg: #000000;
   --fg: #ffffff;
@@ -29,6 +30,55 @@
   --data-mint: #4cdc8b;
   --data-blue: #4c7fdc;
   --error: #e46962;
+  /* Helpers that invert per-theme so the same markup reads on both canvases */
+  --bg-scrim: rgba(0, 0, 0, 0.8);
+  --on-accent: #000000; /* text color sitting on a lime fill */
+  --dust: rgba(255, 255, 255, 0.18);
+  --dust-soft: rgba(255, 255, 255, 0.1);
+  --dust-accent: rgba(222, 255, 154, 0.2);
+  --grid: rgba(255, 255, 255, 1);
+  --grid-opacity: 0.06;
+  --mask-fill: #fff;
+  --star: #ffffff;
+  --outline: rgba(255, 255, 255, 0.2);
+  --outline-strong: rgba(255, 255, 255, 0.25);
+}
+
+/* Light theme — "Paper Particles". Inverts the canvas while keeping the
+   single-accent discipline: lime becomes a darker olive (#3E5A12) so the
+   emphasis reads on white — per DESIGN.md "Don't place lime text on white". */
+:root[data-theme='light'] {
+  --bg: #ffffff;
+  --fg: #0a0a0a;
+  --fg-muted: #4a4a4a;
+  --fg-dim: #6f6f6f;
+  --accent: #3e5a12;
+  --accent-hover: #2c4109;
+  --accent-ink: #ffffff;
+  --accent-halo: rgba(62, 90, 18, 0.28);
+  --accent-ring: rgba(62, 90, 18, 0.22);
+  --surface-0: #fafafa;
+  --surface-1: #f4f4f4;
+  --surface-2: #ececec;
+  --card: #f5f5f5;
+  --card-raised: #ebebeb;
+  --card-edge: #d8d8d8;
+  --line: #e4e4e4;
+  --line-soft: rgba(0, 0, 0, 0.08);
+  --data-mint: #2e9a5c;
+  --data-blue: #2a5bc0;
+  --error: #c0392b;
+  --bg-scrim: rgba(255, 255, 255, 0.82);
+  --on-accent: #ffffff;
+  --dust: rgba(10, 10, 10, 0.08);
+  --dust-soft: rgba(10, 10, 10, 0.05);
+  --dust-accent: rgba(62, 90, 18, 0.12);
+  --grid: rgba(10, 10, 10, 1);
+  --grid-opacity: 0.04;
+  --mask-fill: #000;
+  --star: #0a0a0a;
+  --outline: rgba(10, 10, 10, 0.14);
+  --outline-strong: rgba(10, 10, 10, 0.22);
 }
 
 * {
@@ -46,6 +96,10 @@ html {
   scroll-behavior: smooth;
 }
 
+html[data-theme='light'] {
+  color-scheme: light;
+}
+
 body {
   margin: 0;
   color: var(--fg);
@@ -54,9 +108,9 @@ body {
   font-feature-settings: "ss01", "cv11";
   background-color: var(--bg);
   background-image:
-    radial-gradient(ellipse 1200px 600px at 18% -8%, rgba(222, 255, 154, 0.05), transparent 55%),
-    radial-gradient(ellipse 1000px 520px at 108% 22%, rgba(76, 220, 139, 0.04), transparent 60%),
-    radial-gradient(ellipse 900px 500px at 50% 120%, rgba(222, 255, 154, 0.03), transparent 68%);
+    radial-gradient(ellipse 1200px 600px at 18% -8%, var(--dust-accent), transparent 55%),
+    radial-gradient(ellipse 1000px 520px at 108% 22%, var(--dust-soft), transparent 60%),
+    radial-gradient(ellipse 900px 500px at 50% 120%, var(--dust-accent), transparent 68%);
   overflow-x: hidden;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
@@ -70,12 +124,12 @@ body::before {
   pointer-events: none;
   z-index: 0;
   background-image:
-    radial-gradient(circle at 12% 18%, rgba(255, 255, 255, 0.18) 0%, transparent 0.6%),
-    radial-gradient(circle at 72% 28%, rgba(255, 255, 255, 0.12) 0%, transparent 0.5%),
-    radial-gradient(circle at 38% 52%, rgba(222, 255, 154, 0.2) 0%, transparent 0.4%),
-    radial-gradient(circle at 88% 62%, rgba(255, 255, 255, 0.14) 0%, transparent 0.5%),
-    radial-gradient(circle at 22% 78%, rgba(255, 255, 255, 0.1) 0%, transparent 0.5%),
-    radial-gradient(circle at 62% 88%, rgba(222, 255, 154, 0.16) 0%, transparent 0.4%);
+    radial-gradient(circle at 12% 18%, var(--dust) 0%, transparent 0.6%),
+    radial-gradient(circle at 72% 28%, var(--dust-soft) 0%, transparent 0.5%),
+    radial-gradient(circle at 38% 52%, var(--dust-accent) 0%, transparent 0.4%),
+    radial-gradient(circle at 88% 62%, var(--dust) 0%, transparent 0.5%),
+    radial-gradient(circle at 22% 78%, var(--dust-soft) 0%, transparent 0.5%),
+    radial-gradient(circle at 62% 88%, var(--dust-accent) 0%, transparent 0.4%);
   background-size: 100% 100%;
   opacity: 0.9;
   mask-image: radial-gradient(ellipse at 50% 30%, black, transparent 85%);
@@ -88,10 +142,10 @@ body::after {
   inset: 0;
   pointer-events: none;
   z-index: 0;
-  opacity: 0.06;
+  opacity: var(--grid-opacity);
   background-image:
-    linear-gradient(rgba(255, 255, 255, 1) 1px, transparent 1px),
-    linear-gradient(90deg, rgba(255, 255, 255, 1) 1px, transparent 1px);
+    linear-gradient(var(--grid) 1px, transparent 1px),
+    linear-gradient(90deg, var(--grid) 1px, transparent 1px);
   background-size: 64px 64px;
   mask-image: radial-gradient(ellipse at 50% 30%, black, transparent 70%);
 }
@@ -269,7 +323,7 @@ a:focus-visible {
 .btn-pill.ghost {
   background: transparent;
   color: var(--fg);
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  border: 1px solid var(--outline);
 }
 
 .btn-pill.ghost:hover {
@@ -278,9 +332,9 @@ a:focus-visible {
 }
 
 .btn-pill.dark {
-  background: #000;
+  background: var(--bg);
   color: var(--fg);
-  border: 1px solid rgba(255, 255, 255, 0.2);
+  border: 1px solid var(--outline);
 }
 
 .btn-pill.dark:hover {
@@ -313,7 +367,7 @@ a:focus-visible {
 
 .btn-chevron.ghost {
   background: transparent;
-  border: 1px solid rgba(255, 255, 255, 0.25);
+  border: 1px solid var(--outline-strong);
   color: var(--fg);
 }
 
@@ -373,14 +427,23 @@ a:focus-visible {
 
 /* ==================== Terminal / code block ==================== */
 
+/* Terminals stay dark in both themes — they represent a shell and the
+   design system explicitly allows dark "onyx" islands on a bright canvas. */
 .term {
-  background: #0c0c0c;
-  border: 1px solid var(--line);
+  --term-bg: #0c0c0c;
+  --term-head: #0a0a0a;
+  --term-fg: #ffffff;
+  --term-fg-muted: #c8c8c8;
+  --term-fg-dim: #8a8a8a;
+  --term-line: #262626;
+  background: var(--term-bg);
+  border: 1px solid var(--term-line);
   border-radius: 16px;
   overflow: hidden;
   font-family: var(--font-mono);
   font-size: 0.8125rem;
   line-height: 1.6;
+  color: var(--term-fg);
 }
 
 .term.accented {
@@ -412,10 +475,10 @@ a:focus-visible {
   align-items: center;
   gap: 10px;
   padding: 12px 16px;
-  border-bottom: 1px solid var(--line);
-  background: #0a0a0a;
+  border-bottom: 1px solid var(--term-line);
+  background: var(--term-head);
   font-size: 0.75rem;
-  color: var(--fg-dim);
+  color: var(--term-fg-dim);
 }
 
 .term-dots {
@@ -436,43 +499,47 @@ a:focus-visible {
 
 .term-body {
   padding: 22px 24px;
-  color: var(--fg);
+  color: var(--term-fg);
   overflow-x: auto;
 }
 
+/* Terminal signals keep their lime/mint accents on the dark shell surface
+   regardless of page theme — lime-on-black is the dark-first signature. */
 .term-prompt {
-  color: var(--accent);
+  color: #deff9a;
   user-select: none;
 }
 
 .term-cmd {
-  color: var(--fg);
+  color: var(--term-fg);
   font-weight: 500;
 }
 
 .term-out {
-  color: var(--fg-muted);
+  color: var(--term-fg-muted);
 }
 
 .term-ok {
-  color: var(--data-mint);
+  color: #4cdc8b;
 }
 
 .term-arrow {
-  color: var(--accent);
+  color: #deff9a;
 }
 
 .term-comment {
-  color: var(--fg-dim);
+  color: var(--term-fg-dim);
 }
 
 /* YAML syntax tones */
 .yml-key { color: var(--accent); font-weight: 500; }
-.yml-str { color: #e5f4c7; }
-.yml-num { color: var(--data-blue); }
-.yml-bool { color: var(--data-mint); }
-.yml-comment { color: var(--fg-dim); font-style: italic; }
-.yml-punct { color: var(--fg-dim); }
+/* YAML tones sit inside the dark terminal surface — keep them theme-invariant. */
+.term .yml-key { color: #deff9a; }
+.term .yml-str { color: #e5f4c7; }
+.term .yml-num { color: #4c7fdc; }
+.term .yml-bool { color: #4cdc8b; }
+.term .yml-comment { color: #8a8a8a; font-style: italic; }
+.term .yml-punct { color: #8a8a8a; }
 
 /* ==================== Animations ==================== */
 
@@ -632,7 +699,7 @@ a:focus-visible {
   font-size: 0.75rem;
   font-weight: 400;
   letter-spacing: 0.02em;
-  color: #aaaaaa;
+  color: var(--fg-dim);
 }
 
 .footer-ticker .center {


### PR DESCRIPTION
## Summary
- Adds a three-state theme toggle (system / light / dark) in the header
- Defines a light palette that inverts the canvas while keeping the single-accent discipline: dark olive (#3E5A12) carries emphasis on white, lime (#DEFF9A) stays the dark-mode signature (lime on white fails contrast per DESIGN.md)
- Respects OS preference on first visit and listens for changes; stored pick takes priority
- Pre-hydration inline script sets `data-theme` before first paint so the right palette is there on the first frame

## What changed
- `src/styles.css`: new `:root[data-theme='light']` scope, new helpers (`--bg-scrim`, `--on-accent`, `--dust`, `--grid`, `--outline`, etc.) so body dust/grid, ghost borders, star fills, and the header scrim follow the theme. Terminals now use their own `--term-*` scale so code blocks stay dark in both modes (consistent with the design system's "bright-card inversion" rule — a dark island on a bright canvas)
- `src/components/ThemeToggle.tsx` (new): cycles system → light → dark, persists to `localStorage`, listens to `prefers-color-scheme` while set to system
- `src/components/Header.tsx`: toggle placed next to the "Star on GitHub" CTA; hardcoded `bg-black/80`, `text-white`, `bg-black` replaced with theme vars
- `src/routes/__root.tsx`: inline pre-hydration script sets `data-theme` before React mounts
- `src/components/Footer.tsx`, `src/components/InstallBlock.tsx`, `src/components/NewsletterForm.tsx`, `src/routes/index.tsx`: remaining `text-white` / `bg-black` / `#ffffff` / `#aaaaaa` references converted to CSS variables

## Design notes
- Keeps lime as the dark-mode signature; shifts to `#3E5A12` dark olive as the emphasis hue on white (same choice as the docs PR), so the "machine", "agent", "in one command" accent words still read from across the page
- Primary CTA pill reads as an olive-on-white pill with white text in light mode (driven by `--accent` / `--accent-ink` flip); lime-on-black pill in dark mode unchanged
- Terminal shells (`.term`) stay dark in both modes — the design system explicitly allows onyx islands on a bright canvas

## Test plan
- [x] `pnpm dev` + headless Chrome: dark and light screenshots look correct (hero, problem section, how-it-works, import terminal, install cards, coverage, trust row, final CTA, footer)
- [x] Theme toggle appears in header (sun / moon / monitor icons depending on state)
- [x] Pre-hydration script applies stored theme without FOUC
- [x] OS `prefers-color-scheme` change flips the theme while in "system" mode
- [x] `tsc --noEmit` clean
- [ ] Reviewer: spot check on mobile viewport (the toggle shrinks to `ml-auto` before the CTA pair)
- [ ] Reviewer: Plausible events still fire (unchanged, but worth a glance)